### PR TITLE
bashs-find-command: fix of a small typo

### DIFF
--- a/article/bashs-find-command/index.html
+++ b/article/bashs-find-command/index.html
@@ -228,7 +228,7 @@ clear:</p>
 </code></pre>
 <p><a href="https://www.gnu.org/software/findutils/manual/html_mono/find.html#Combining-Primaries-With-Operators">More about operators</a></p>
 <h3 id="actions">Actions</h3>
-<p>Now, printing out the filenames if fun, doing some stuff with them is even
+<p>Now, printing out the filenames is fun, doing some stuff with them is even
 better! And guess why it actually prints out the filenames: because the default
 action is <code>-print</code>!</p>
 <pre><code class="language-bash">$ find -type f -print


### PR DESCRIPTION
Thank you for the guide. Needed a refresher and found your github.io.
I think the 'if' should be a 'is'.